### PR TITLE
Fix build error in GitHub Action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '20'
+          node-version: '16'
 
       - name: Install dependencies
         run: npm install

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -22,5 +22,8 @@
     "gh-pages": "^3.2.3"
   },
   "author": "Dan Velton",
-  "license": "MIT"
+  "license": "MIT",
+  "engines": {
+    "node": "16.x"
+  }
 }


### PR DESCRIPTION
Update Node.js version in GitHub Action to fix build error.

* Change `node-version` from '20' to '16' in `.github/workflows/deploy.yml`.
* Add `engines` field specifying Node.js version '16.x' in `webapp/package.json`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/khxu/hotseat-mediator/pull/3?shareId=2d70b6e3-440e-4980-aca2-67b1a78f83a5).